### PR TITLE
[FIX] Avoid unverified users to login

### DIFF
--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -1,6 +1,7 @@
 import { Controller, Post, Body, Param, Get } from '@nestjs/common';
 import {
 	ApiBadRequestResponse,
+	ApiForbiddenResponse,
 	ApiNotFoundResponse,
 	ApiOkResponse,
 	ApiOperation,
@@ -33,6 +34,7 @@ export class AuthController {
 	@Post('login')
 	@ApiOperation({ summary: 'Sign in a user with email and password' })
 	@ApiUnauthorizedResponse({ description: 'Unauthorized, password invalid' })
+	@ApiForbiddenResponse({ description: 'Forbidden, email not verified' })
 	@ApiNotFoundResponse({ description: 'User not found' })
 	@ApiOkResponse({ description: 'OK', type: TokenDTO })
 	async login(@Body() signInDto: UserSignInDTO): Promise<TokenDTO> {

--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -1,7 +1,7 @@
 import type { email } from '#types';
 import type { JWTPayload } from '#types/api';
 
-import { Injectable, UnauthorizedException } from '@nestjs/common';
+import { ForbiddenException, Injectable, UnauthorizedException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { JwtService } from '@nestjs/jwt';
 import { compareSync } from 'bcrypt';
@@ -32,6 +32,10 @@ export class AuthService {
 
 		if (user.password !== pass && !compareSync(pass, user.password)) {
 			throw new UnauthorizedException(this.t.Errors.Password.Mismatch());
+		}
+
+		if (!user.verified) {
+			throw new ForbiddenException(this.t.Errors.Email.NotVerified(User));
 		}
 
 		const payload = { sub: user.id, email: user.email };


### PR DESCRIPTION
## Changes

- Added a verification step in `AuthService.signIn()`: if the user is not verified throw a `ForbiddenException`
- Adapted logs e2e tests to use a verified user

## Fixes

- #17 